### PR TITLE
Modify led to support blink.

### DIFF
--- a/demo/led.html
+++ b/demo/led.html
@@ -13,6 +13,11 @@
     font-size: 20px;
   }
   
+  input, button {
+    width: 100px;
+    margin: 5px 0;
+  }
+  
   #msg.default::after {
     content: "訊息";
   }
@@ -66,6 +71,17 @@
     <button id='off' class="btns" type="button">OFF</button>
     <button id='toggle' class="btns" type="button">TOGGLE</button>
   </div>
+  <div class="container">
+    <p>Set blink interval and click button to start blinking.</p>
+    <label>Blink interval(ms): </label><input id="blink-interval" type="number" value="1000">
+    <button id="blink" class="btns" type="button">BLINK</button>
+    <button id="stop-blink" class="btns" type="button">STOP</button>
+  </div>
+  <div class="container">
+    <p>Change led state to on/off/blink (1000 as blink interval).</p>
+    <label>Current State: </label><input id="ledstate">
+    <button id="set-state" class="btns" type="button">SET</button>
+  </div>
   <p>led pin : 10</p>
   <p>控制 LED</p>
   <p id='ledstatus'>none</p>
@@ -79,7 +95,12 @@
       onBtn = document.getElementById('on'),
       offBtn = document.getElementById('off'),
       toggleBtn = document.getElementById('toggle'),
-      ledstatus = document.getElementById('ledstatus');
+      ledstatus = document.getElementById('ledstatus'),
+      blinkInterval = document.getElementById('blink-interval'),
+      blinkBtn = document.getElementById('blink'),
+      stopBlinkBtn = document.getElementById('stop-blink'),
+      ledstate = document.getElementById('ledstate'),
+      setStateBtn = document.getElementById('set-state');
 
     device.setAttribute('value', localStorage.device || "");
 
@@ -103,8 +124,14 @@
     }
 
     function run() {
+
+      var statecb = function() {
+        ledstate.value = led.state;
+      }
+      statecb();
+
       onBtn.addEventListener('click', function(e) {
-        led.on();
+        led.on(statecb);
         ledstatus.innerHTML = "led on!";
         e.stopPropagation();
         e.preventDefault();
@@ -112,7 +139,7 @@
       }, false);
 
       offBtn.addEventListener('click', function(e) {
-        led.off();
+        led.off(statecb);
         ledstatus.innerHTML = "led off!";
         e.stopPropagation();
         e.preventDefault();
@@ -120,8 +147,31 @@
       }, false);
 
       toggleBtn.addEventListener('click', function(e) {
-        led.toggle();
+        led.toggle(statecb);
         ledstatus.innerHTML = "led toggle!";
+        e.stopPropagation();
+        e.preventDefault();
+        return false;
+      }, false);
+
+      blinkBtn.addEventListener('click', function(e) {
+        led.blink(blinkInterval.value, statecb);
+        ledstatus.innerHTML = "led blinks!";
+        e.stopPropagation();
+        e.preventDefault();
+        return false;
+      }, false);
+
+      stopBlinkBtn.addEventListener('click', function(e) {
+        led.stopBlink(statecb);
+        ledstatus.innerHTML = "led stopped!";
+        e.stopPropagation();
+        e.preventDefault();
+        return false;
+      }, false);
+
+      setStateBtn.addEventListener('click', function(e) {
+        led.state = ledstate.value;
         e.stopPropagation();
         e.preventDefault();
         return false;

--- a/demo/led.html
+++ b/demo/led.html
@@ -75,7 +75,6 @@
     <p>Set blink interval and click button to start blinking.</p>
     <label>Blink interval(ms): </label><input id="blink-interval" type="number" value="1000">
     <button id="blink" class="btns" type="button">BLINK</button>
-    <button id="stop-blink" class="btns" type="button">STOP</button>
   </div>
   <div class="container">
     <p>Change led state to on/off/blink (1000 as blink interval).</p>
@@ -98,7 +97,6 @@
       ledstatus = document.getElementById('ledstatus'),
       blinkInterval = document.getElementById('blink-interval'),
       blinkBtn = document.getElementById('blink'),
-      stopBlinkBtn = document.getElementById('stop-blink'),
       ledstate = document.getElementById('ledstate'),
       setStateBtn = document.getElementById('set-state');
 
@@ -127,7 +125,10 @@
 
       var statecb = function() {
         ledstate.value = led.state;
-      }
+        if(led.state === 'blink') {
+          ledstatus.innerHTML = (this._pin.value) ? "led blinks!(on)" : "led blinks!(off)";
+        }
+      };
       statecb();
 
       onBtn.addEventListener('click', function(e) {
@@ -157,14 +158,6 @@
       blinkBtn.addEventListener('click', function(e) {
         led.blink(blinkInterval.value, statecb);
         ledstatus.innerHTML = "led blinks!";
-        e.stopPropagation();
-        e.preventDefault();
-        return false;
-      }, false);
-
-      stopBlinkBtn.addEventListener('click', function(e) {
-        led.stopBlink(statecb);
-        ledstatus.innerHTML = "led stopped!";
         e.stopPropagation();
         e.preventDefault();
         return false;

--- a/wa-led.html
+++ b/wa-led.html
@@ -48,9 +48,11 @@
 
       this.led = new Led(board, board.getDigitalPin(this.pin));
 
-      if (this.state === 'on') {
-        this.on();
-      }
+      this._statecb = null;
+      this._blinkInterval = null;
+
+      // Initial led state according to wa-led state
+      this.attributeChangedCallback('state', null, this.state);
     };
 
     proto.createGnd_ = function() {
@@ -67,23 +69,82 @@
       }
     };
 
+    /**
+     * Set led state to on.
+     * @param {Function} [callback] - Led state changed callback.
+     */
     proto.on = function(callback) {
-      this.led.on(callback);
+      this._statecb = callback;
+      this.state = 'on';
+    };
+    proto._on = function() {
+      this.led.on(this._statecb);
     };
 
+    /**
+     * Set led state to off.
+     * @param {Function} [callback] - Led state changed callback.
+     */
     proto.off = function(callback) {
-      this.led.off(callback);
+      this._statecb = callback;
+      this.state = 'off';
+    };
+    proto._off = function() {
+      this.led.off(this._statecb);
     };
 
+    /**
+     * Toggle led state between on/off according to current state.
+     * @param {Function} [callback] - Led state changed callback.
+     */
     proto.toggle = function(callback) {
-      this.led.toggle(callback);
+      this._statecb = callback;
+      this.state = this.state === 'blink' || this.state === 'on' ? 'off' : 'on';
+    };
+
+    /**
+     * Set led state to blink. Both msec and callback are optional
+     * and can be passed as the only one parameter.
+     * @param {number} [msec] - Led blinking interval.
+     * @param {Function} [callback] - Led state changed callback.
+     */
+    proto.blink = function(msec, callback) {
+      if (arguments.length === 1 && typeof arguments[0] === 'function') {
+        callback = arguments[0];
+      }
+      this.state = null;
+      this._blinkInterval = msec;
+      this._statecb = callback;
+      this.state = 'blink';
+    };
+    proto._blink = function() {
+      this.led.blink(this._blinkInterval, this._statecb);
+    };
+
+    /**
+     * Stop led blinking.
+     * @param {Function} [callback] - Led state changed callback.
+     */
+    proto.stopBlink = function(callback) {
+      if (this.state === 'blink') {
+        this._statecb = callback;
+        this.state = 'off';
+      }
     };
 
     proto.attributeChangedCallback = function(attrName, oldVal, newVal) {
       if (this.led) {
         switch (attrName) {
           case 'state':
-            newVal === "on" ? this.on() : this.off();
+            if (newVal === 'on') {
+              this._on();
+            } else if (newVal === 'off') {
+              this._off();
+            } else if (newVal === 'blink') {
+              this._blink();
+              this._blinkInterval = null;
+            }
+            this._statecb = null;
             break;
           case 'gnd':
             this.createGnd_();

--- a/wa-led.html
+++ b/wa-led.html
@@ -121,17 +121,6 @@
       this.led.blink(this._blinkInterval, this._statecb);
     };
 
-    /**
-     * Stop led blinking.
-     * @param {Function} [callback] - Led state changed callback.
-     */
-    proto.stopBlink = function(callback) {
-      if (this.state === 'blink') {
-        this._statecb = callback;
-        this.state = 'off';
-      }
-    };
-
     proto.attributeChangedCallback = function(attrName, oldVal, newVal) {
       if (this.led) {
         switch (attrName) {


### PR DESCRIPTION
# Led blink support
- Add blink and stopBlink functions in wa-led.
- Add 'blink' state in wa-led.
- Modify state attribute changing part to make led component state synchronized.
- Modify demo/led.html.

## Usage
### Blink
Call led.blink with blink interval(ms) and callback function:
```javascript
led.blink(1000, callback);
```
Parameters are optional and can be passed as the only one parameter:
```javascript
led.blink();
led.blink(1000);
led.blink(callback);
```
Or change the component state attribute to 'blink':
```javascript
led.state = 'blink';
```

### Stop blink
Simply call the stopBlink function:
```javascript
led.stopBlink();
led.stopBlink(callback);
```
The component state will be changed to 'off' when stop blinking.

### State attribute change
State attribute of led component can be set to 'on' / 'off' / 'blink', then will execute led control functions.
```javascript
led.state = 'on';
led.state = 'off';
led.state = 'blink';
```
The state attribute can be initialized in html.
```html
<wa-led id='led' pin='10' state='blink'></wa-led>
```
Notice that change state cannot set the callback and blink interval directly.